### PR TITLE
Create the base structure to use CLI commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ewbscp
+_build/**

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: help build run
+
+ifeq (run,$(firstword $(MAKECMDGOALS)))
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(RUN_ARGS):;@:)
+endif
+
+ifeq (zip,$(firstword $(MAKECMDGOALS)))
+  ZIP_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(ZIP_ARGS):;@:)
+endif
+
+help:
+	@echo "Usage:"
+	@echo "  make build                   - Builds project with Mix"
+	@echo "  make run <path> -- [<flags>] - Execute the compiled file and <path> doesn't have quotes"
+	@echo "  make zip <path> -- [<flags>] - Same as run, but it builds before running"
+	@echo "   || possible flags:"
+	@echo "   ||   --allow-empty :: Includes empty directories"
+	@echo ""
+	@echo "  make help                    - Shows this help"
+
+build:
+	@echo "Building"
+	@mix escript.build
+
+run:
+	@./ewbscp $(RUN_ARGS)
+
+zip: build
+	@./ewbscp $(ZIP_ARGS)
+
+%:
+	@$(MAKE) help

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # ewbscp
 
+## Usage
+First, make sure you have `make` installed on your sistem. Then:
+
+```
+$ make help
+
+Usage:
+  make build                   - Builds project with Mix
+  make run <path> -- [<flags>] - Execute the compiled file and <path> doesn't have quotes
+  make zip <path> -- [<flags>] - Same as run, but it builds before running
+   || possible flags:
+   ||   --allow-empty :: Includes empty directories
+
+  make help                    - Shows this help
+```
+
 ## Architecture implementation
 ### Namespace convention
 

--- a/lib/adapter/external/cli.ex
+++ b/lib/adapter/external/cli.ex
@@ -7,7 +7,7 @@ defmodule CLI do
     with {options, [directory], []} <- parsed,
          true <- File.dir?(directory),
          {:ok, files} <- list_files(directory) do
-      Enum.reduce(files, 0, fn file, size -> size + calculate_file_size(file) end)
+      Enum.reduce(files, 0, &(&2 + calculate_file_size(&1)))
       |> print_size(files, options)
     else
       _ ->

--- a/lib/adapter/external/cli.ex
+++ b/lib/adapter/external/cli.ex
@@ -1,0 +1,54 @@
+defmodule CLI do
+  def main(args) do
+    parsed =
+      args
+      |> OptionParser.parse(strict: [allow_empty: :boolean])
+
+    with {options, [directory], []} <- parsed,
+         true <- File.dir?(directory),
+         {:ok, files} <- list_files(directory) do
+      Enum.reduce(files, 0, fn file, size -> size + calculate_file_size(file) end)
+      |> print_size(files, options)
+    else
+      _ ->
+        IO.puts("Invalid input")
+        System.halt(1)
+    end
+  end
+
+  defp print_size(0, _, options) do
+    case Keyword.get(options, :allow_empty) do
+      true ->
+        IO.puts("0")
+
+      _ ->
+        IO.puts("Empty directory")
+        System.halt(1)
+    end
+  end
+
+  defp print_size(total_size, files, _) do
+    IO.puts(div(total_size, length(files)))
+  end
+
+  defp list_files(directory) do
+    case File.ls(directory) do
+      {:ok, files} ->
+	    files =
+          files
+          |> Enum.map(&Path.join(directory, &1))
+          |> Enum.reject(&File.dir?/1)
+
+		{:ok, files}
+
+      error ->
+        error
+    end
+  end
+
+  defp calculate_file_size(file) do
+    file
+    |> File.stat!()
+    |> Map.get(:size)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,8 @@ defmodule Ewbscp.MixProject do
       version: "0.1.0",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      escript: [main_module: CLI]
     ]
   end
 


### PR DESCRIPTION
### Rationale
Use CLI as an input for our core logics, since it's easier to test (and probably our first milestone). With this in mind, I've created a boilerplate code within `adapter/external/cli.ex` - since it's an external input entering our program. 

For now, it'll handle everything inside this module - but the idea for the next iteration over CLI is to separate the responsibilities between our architecture decisions so we can enhance it - not focusing on the `application` part of it - that's for the 3rd iteration.

### Highlights
- **Boilerplate code** :: I did put some code there that accepts a **path** and an _optional flag_ to fetch the size of the specified path. 
- **Learn mechanism** :: It uses a little bit of everything, which shows its strengths and limitations, like:
  - [x] it handles arguments and flags
  - [x] it read files based on a path
  - [x] it has error handling with `Invalid input` and `Empty directory` cases
